### PR TITLE
remove ip and port log

### DIFF
--- a/kxkdb/src/ipc/connection.rs
+++ b/kxkdb/src/ipc/connection.rs
@@ -910,7 +910,6 @@ async fn connect_tcp_impl(host: &str, port: u16) -> Result<TcpStream> {
         // Return if this IP address is valid
         match TcpStream::connect(&host_port).await {
             Ok(socket) => {
-                println!("connected: {}", host_port);
                 return Ok(socket);
             }
             Err(_) => {


### PR DESCRIPTION
This pull request remove ip and port logging when connecting to a kdb process using tcp connection.